### PR TITLE
Add support for freebsd

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,12 +34,26 @@ mod imp {
 mod imp {
   #[link(name = "pthread")]
   extern "C" {
-    fn pthread_threadid_np(thread: libc::pthread_t, thread_id: *mut libc::uint64_t) -> libc::c_int;
+    fn pthread_threadid_np(thread: libc::pthread_t, thread_id: *mut u64) -> libc::c_int;
   }
 
   pub fn gettid() -> u64 {
     let mut result = 0;
     unsafe {let _ = pthread_threadid_np(0, &mut result); }
+    result
+  }
+}
+
+#[cfg(target_os = "freebsd")]
+mod imp {
+  #[link(name = "pthread")]
+  extern "C" {
+    fn pthread_getthreadid_np(thread: libc::pthread_t, thread_id: *mut u64) -> libc::c_int;
+  }
+
+  pub fn gettid() -> u64 {
+    let mut result = 0;
+    unsafe {let _ = pthread_getthreadid_np(0, &mut result); }
     result
   }
 }


### PR DESCRIPTION
Adds support for FreeBSD.
Also fix deprecation warning relating to libc::uint64_t.
Developed & tested on FreeBSD 13.2-RELEASE-p11, rust v1.79.0 (stable).